### PR TITLE
pullSolutions with branch option

### DIFF
--- a/src/main/scala/com/typesafe/training/sbtkoan/Koan.scala
+++ b/src/main/scala/com/typesafe/training/sbtkoan/Koan.scala
@@ -59,10 +59,10 @@ private class Koan(state: State, koanArg: KoanArg) {
   def apply(): State = {
     import KoanArg._
     koanArg match {
-      case Show          => show()
-      case Next          => move(forward = true)
-      case Prev          => move(forward = false)
-      case PullSolutions => pullSolutions()
+      case Show         => show()
+      case Next         => move(forward = true)
+      case Prev         => move(forward = false)
+      case Pull(branch) => pull(branch)
     }
   }
 
@@ -106,14 +106,12 @@ private class Koan(state: State, koanArg: KoanArg) {
     }
   }
 
-  def pullSolutions(): State = {
+  def pull(branch: String): State = {
     try {
-      val tag = FileUtils.readFileToString(new File(baseDirectory, ".tag"), utf8).trim
-      git.fetch("origin", s"$tag-solutions")
-      git.resetHard(s"origin/$tag-solutions")
+      git.fetch("origin", s"$branch")
+      git.resetHard(s"origin/$branch")
       state.log.info(s"Pulled solutions into workspace")
     } catch {
-      case e: IOException     => state.log.error(s"Can't pull solutions, because .tag file can't be read: ${e.getMessage}")
       case e: GitAPIException => state.log.error(s"Can't pull solutions, because of Git error: ${e.getMessage}")
     }
     state

--- a/src/main/scala/com/typesafe/training/sbtkoan/KoanArg.scala
+++ b/src/main/scala/com/typesafe/training/sbtkoan/KoanArg.scala
@@ -7,12 +7,8 @@ package com.typesafe.training.sbtkoan
 private sealed trait KoanArg
 
 private object KoanArg {
-
   case object Show extends KoanArg
-
   case object Next extends KoanArg
-
   case object Prev extends KoanArg
-
-  case object PullSolutions extends KoanArg
+  case class Pull(branch: String) extends KoanArg
 }

--- a/src/main/scala/com/typesafe/training/sbtkoan/SbtKoan.scala
+++ b/src/main/scala/com/typesafe/training/sbtkoan/SbtKoan.scala
@@ -7,6 +7,8 @@ package com.typesafe.training.sbtkoan
 import sbt.{ AutoPlugin, Command, Configuration, Configurations, Keys, PluginTrigger, Setting, SettingKey, State }
 import sbt.complete.{ DefaultParsers, Parser }
 
+import scala.reflect._
+
 object SbtKoan extends AutoPlugin {
 
   object autoImport {
@@ -38,7 +40,7 @@ object SbtKoan extends AutoPlugin {
     val ignoreFiles: SettingKey[Set[String]] =
       SettingKey[Set[String]](
         prefixed("ignorePaths"),
-        "If a file has one of these paths relative to the project root directory, it is ignored; Set.emtpy by default"
+        "If a file has one of these paths relative to the project root directory, it is ignored; Set.empty by default"
       )
 
     private def prefixed(key: String) = s"koan${key.capitalize}"
@@ -65,6 +67,11 @@ object SbtKoan extends AutoPlugin {
     import KoanArg._
     def arg(koanArg: KoanArg): Parser[KoanArg] =
       (Space ~> koanArg.toString.decapitalize).map(_ => koanArg)
-    arg(Show) | arg(Next) | arg(Prev) | arg(PullSolutions)
+    def stringOpt[A <: KoanArg: ClassTag](ctor: String => A): Parser[A] = {
+      val name = classTag[A].runtimeClass.getSimpleName
+      (Space ~> name.decapitalize ~> "=" ~> NotQuoted).map(ctor)
+    }
+
+    arg(Show) | arg(Next) | arg(Prev) | stringOpt(Pull)
   }
 }


### PR DESCRIPTION
The students can specify a branch name from which the current state is pulled. This allows training to only create course materials when a new course version will be released and still pull and push solutions. The corresponding PR in `sbt-groll` is: https://github.com/sbt/sbt-groll/pull/6
