### PR TITLE
Upgrade JGit version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Version {
   val commonsIO = "2.4"
-  val jGit      = "3.4.1.201406201815-r"
+  val jGit      = "4.0.1.201506240215-r"
   val scala     = "2.10.4"
   val scalaTest = "2.2.2"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.6
+sbt.version = 0.13.8

--- a/src/main/scala/com/typesafe/training/sbtkoan/Git.scala
+++ b/src/main/scala/com/typesafe/training/sbtkoan/Git.scala
@@ -49,7 +49,7 @@ class Git(repository: Repository) {
         parser.reset(reader, tree.getId)
         parser
       } finally
-        reader.release()
+        reader.close()
     }
     def matches(entry: DiffEntry) = {
       val allPaths = path +: paths.toList


### PR DESCRIPTION
sbt-groll 4.8.0 upgraded its Jgit dependency, which is incompatible with 0.3 that koan depended on.